### PR TITLE
adjust parent label display in the error summary

### DIFF
--- a/projects/hpfb/sdk/ui/error-msg/error-summary/error-summary.component.html
+++ b/projects/hpfb/sdk/ui/error-msg/error-summary/error-summary.component.html
@@ -38,13 +38,11 @@
         <li *ngIf="controlError.type!=='component_error' && controlError.type!='least_one_rec_error'">
           <a href="#{{controlError.controlId}}" target="_self" (click)="processEvents(controlError)">
             {{'error' | translate: {number:controlError.errorNumber} }}
-            @if(this.headingLevel==='h4'){
+            
               @if(controlError.compRef.translatedParentLabel) {
                 {{controlError.compRef.translatedParentLabel}}&nbsp;&#8208;&nbsp;
-              } @else {
-                {{controlError.compRef.parentLabel | translate}}&nbsp;&#8208;&nbsp;
               }
-            } 
+            
             {{controlError.compRef.label | translate}}&nbsp;&#8208;&nbsp;{{ getValidatorErrorMessageKey(controlError.compRef.currentError) | translate: controlError.compRef.errorParams}}
           </a>
         </li>

--- a/projects/md-ai/src/app/inter-device/device-item/device-item.component.html
+++ b/projects/md-ai/src/app/inter-device/device-item/device-item.component.html
@@ -13,7 +13,7 @@
                                   [showError]="showErrors"
                                   [control]="cRRow.get('deviceInfo.deviceName') | formControl"
                                   controlId="deviceName{{j}}" label="device.name" parentId="deviceDetails"
-                                  parentLabel="{{translatedParentLabel}}"></control-messages>
+                                  translatedParentLabel="{{translatedParentLabel}}"></control-messages>
                 <textarea id="deviceName{{j}}" name="deviceName" class="form-control full-width"
                        [formControlName]="'deviceName'" maxlength="150"></textarea>
               </label>
@@ -29,7 +29,7 @@
                                   [showError]="showErrors"
                                   [control]="cRRow.get('deviceInfo.deviceAuthorized') | formControl"
                                   controlId="deviceAuthorized{{j}}" label="device.authorized" parentId="deviceDetails"
-                                  parentLabel="{{translatedParentLabel}}"></control-messages>
+                                  translatedParentLabel="{{translatedParentLabel}}"></control-messages>
       
                 <select id="deviceAuthorized{{j}}" name="deviceAuthorized{{j}}" required class="form-control" (change)="onDeviceAuthorizedChange($event)"
                         [formControlName]="'deviceAuthorized'">
@@ -51,7 +51,7 @@
                     [showError]="showErrors"
                     [control]="cRRow.get('deviceInfo.licenceNum') | formControl"
                     controlId="licenceNum{{j}}" label="licence.application.number" parentId="deviceDetails"
-                    parentLabel="{{translatedParentLabel}}"></control-messages>
+                    translatedParentLabel="{{translatedParentLabel}}"></control-messages>
                   <input id="licenceNum{{j}}" name="licenceNum" class="form-control" data-only-digits maxlength="6"
                         [formControlName]="'licenceNum'" minlength="6" required/>
                 </label>
@@ -66,7 +66,7 @@
                   [showError]="showErrors"
                   [control]="cRRow.get('deviceInfo.deviceApplicationSubmitted') | formControl"
                   controlId="deviceApplicationSubmitted{{j}}" label="device.application.submitted" parentId="deviceDetails"
-                  parentLabel="{{translatedParentLabel}}"></control-messages>
+                  translatedParentLabel="{{translatedParentLabel}}"></control-messages>
       
                 <select id="deviceApplicationSubmitted{{j}}" name="deviceApplicationSubmitted" class="form-control" (change)="onDeviceAppChange($event)"
                         required [formControlName]="'deviceApplicationSubmitted'">
@@ -87,7 +87,7 @@
                   [showError]="showErrors"
                   [control]="cRRow.get('deviceInfo.deviceApplicationNumber') | formControl"
                   controlId="deviceApplicationNumber{{j}}" label="application.number" parentId="deviceDetails"
-                  parentLabel="{{translatedParentLabel}}"></control-messages>
+                  translatedParentLabel="{{translatedParentLabel}}"></control-messages>
                 <input id="deviceApplicationNumber{{j}}" name="deviceApplicationNumber" class="form-control" required
                        data-only-digits maxlength="6" minlength="6" [formControlName]="'deviceApplicationNumber'"/>
               </label>
@@ -103,7 +103,7 @@
                   [showError]="showErrors"
                   [control]="cRRow.get('deviceInfo.deviceExplain') | formControl"
                   controlId="deviceExplain{{j}}" label="device.explain" parentId="deviceDetails"
-                  parentLabel="{{translatedParentLabel}}"></control-messages>
+                  translatedParentLabel="{{translatedParentLabel}}"></control-messages>
                 <textarea id="deviceExplain{{j}}" name="deviceExplain" class="form-control full-width"
                           required [formControlName]="'deviceExplain'" rows="5" maxlength="1000"></textarea> 
               </label>


### PR DESCRIPTION
@AMckayHC @dmiraflorhc this change is for displaying the parent label in different sections (top error summary, eg MF, and component error summary eg. CO contact rep, AI device item ...). 
If you are OK with the change, please approve and merge into Angular17 branch.

![image](https://github.com/hres/AngularApps/assets/37555834/4ec02d8a-999a-429d-bc4a-2cc4ca5ad106)

![image](https://github.com/hres/AngularApps/assets/37555834/52cee968-e4e6-436f-95da-e72d15674408)

![image](https://github.com/hres/AngularApps/assets/37555834/28811fdf-9fd9-4de9-a766-316889eb8c40)
