### PR TITLE
fixed 2 problems

### DIFF
--- a/projects/hpfb/sdk/src/lib/sdk.module.ts
+++ b/projects/hpfb/sdk/src/lib/sdk.module.ts
@@ -1,13 +1,9 @@
 import { NgModule } from '@angular/core';
 import { SdkComponent } from './sdk.component';
 
-
-
 @NgModule({
-  declarations: [
-    SdkComponent
-  ],
   imports: [
+    SdkComponent
   ],
   exports: [
     SdkComponent


### PR DESCRIPTION
fixed 2 problems 

- Component SdkComponent is standalone, and cannot be declared in an NgModule. Did you mean to import it instead?
- Can't be exported from this NgModule, as it must be imported first